### PR TITLE
Ensure routeid protection works even if no session cookie is present

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -26,13 +26,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.startTimer = startTimer;
 
 	const sessionId = event.cookies.get(lucia.sessionCookieName);
-	if (!sessionId) {
-		event.locals.user = null;
-		event.locals.session = null;
-		return resolve(event);
-	}
+	const { session, user } = sessionId
+		? await lucia.validateSession(sessionId)
+		: { session: null, user: null };
 
-	const { session, user } = await lucia.validateSession(sessionId);
 	if (session && session.fresh) {
 		const sessionCookie = lucia.createSessionCookie(session.id);
 		event.cookies.set(sessionCookie.name, sessionCookie.value, {


### PR DESCRIPTION
If there is no session cookie, the request is beeing processed without an auth check.
This can lead to Security vulnerabilities if the auth is not check in the `load` function or form actions either. [example](https://github.com/ak4zh/sveltekit-template/pull/15)